### PR TITLE
Fixing column type to be integer so values can be used as lookup indices

### DIFF
--- a/DataSynthesizer/DataGenerator.py
+++ b/DataSynthesizer/DataGenerator.py
@@ -87,7 +87,7 @@ class DataGenerator(object):
         bn = description['bayesian_network']
         bn_root_attr = bn[0][1][0]
         root_attr_dist = description['conditional_probabilities'][bn_root_attr]
-        encoded_df = pd.DataFrame(columns=DataGenerator.get_sampling_order(bn), dtype=int)
+        encoded_df = pd.DataFrame(columns=DataGenerator.get_sampling_order(bn))
         encoded_df[bn_root_attr] = np.random.choice(len(root_attr_dist), size=n, p=root_attr_dist)
 
         for child, parents in bn:
@@ -110,6 +110,7 @@ class DataGenerator(object):
             encoded_df.loc[encoded_df[child].isnull(), child] = np.random.choice(len(unconditioned_distribution),
                                                                                  size=encoded_df[child].isnull().sum(),
                                                                                  p=unconditioned_distribution)
+        encoded_df[encoded_df.columns] = encoded_df[encoded_df.columns].astype(int)
         return encoded_df
 
     def save_synthetic_data(self, to_file):


### PR DESCRIPTION
This is a solution to issue #6 - though I'm sure other options exist.

According to the Pandas documentation, the default data type for a DataFrame is float64. If DataFrame is initialized but not values are populated into a column, it will ignore the requested datatype (dtype= argument to constructor) and create the columns as float64. While this seems like a bug to me, apparently it is working as designed - though may have worked differently in previous versions of Pandas. See:

https://pandas.pydata.org/pandas-docs/stable/gotchas.html#support-for-integer-na

Additionally, if a column has a NaN or Null value inserted, it will convert the column from int to float.

So, the DataFrame constructor dtype argument is basically ignored, so I removed that as it was likely causing confusion. At the end of the function I've cast everything to int.
