### PR TITLE
Fixing how candidate_keys are being chosen

### DIFF
--- a/DataSynthesizer/ModelInspector.py
+++ b/DataSynthesizer/ModelInspector.py
@@ -22,7 +22,8 @@ class ModelInspector(object):
 
         self.candidate_keys = set()
         for attr in synthetic_df:
-            if synthetic_df[attr].unique().size == synthetic_df.shape[0]:
+            is_candidate = self.attribute_description[attr]['is_candidate_key']
+            if is_candidate:
                 self.candidate_keys.add(attr)
 
         self.private_df.drop(columns=self.candidate_keys, inplace=True)


### PR DESCRIPTION
Existing implementation in ModelInspector selects a column as a candidate key if all of it's values are unique.
However when we synthesize a column that has *float values*, often the synthesized column contains unique float value (since it is float) and satisfies the candidate_key condition. Existing implementation goes on to drop these columns resulting in no inspection using visualizations/correlation matrix.

Instead we can use the information from the attribute_description to know if a column is intended to be a candidate or not.